### PR TITLE
Basic python3 compatibility

### DIFF
--- a/PlistReaderRE/PlistReaderRE.py
+++ b/PlistReaderRE/PlistReaderRE.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 """See docstring for PlistReaderRE class"""
 
+from __future__ import absolute_import
 import os.path
 import glob
 import FoundationPlist

--- a/PlistReaderRE/PlistReaderRE.py
+++ b/PlistReaderRE/PlistReaderRE.py
@@ -18,14 +18,14 @@
 """See docstring for PlistReaderRE class"""
 
 from __future__ import absolute_import
-import os.path
+
 import glob
-import FoundationPlist
+import os.path
 import re
 
-from autopkglib.DmgMounter import DmgMounter
+import FoundationPlist
 from autopkglib import ProcessorError
-
+from autopkglib.DmgMounter import DmgMounter
 
 __all__ = ["PlistReaderRE"]
 


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later, but this should catch the low-hanging fruit right now.