### PR TITLE
Deprecate Dialog recipes in favor of Doko-Phone

### DIFF
--- a/Dialog/Dialog.download.recipe
+++ b/Dialog/Dialog.download.recipe
@@ -13,6 +13,15 @@
 	</dict>
 	<key>Process</key>
 	<array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the Doko-Phone recipes in this repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
 		<dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
The Dialog App is no longer available for download, and appears to be replaced by Doko-Phone. This PR deprecates the Dialog recipes and points users to the Doko-Phone recipes in this repo instead.
