### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/ArchiChect/ArchiChect.pkg.recipe
+++ b/ArchiChect/ArchiChect.pkg.recipe
@@ -82,8 +82,6 @@
 					<string>%RECIPE_CACHE_DIR%/PackageInfo</string>
 					<key>pkgtype</key>
 					<string>flat</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 					<dict>

--- a/Cirrus/Cirrus.pkg.recipe
+++ b/Cirrus/Cirrus.pkg.recipe
@@ -93,8 +93,6 @@
 					<string>%RECIPE_CACHE_DIR%/PackageInfo</string>
 					<key>pkgtype</key>
 					<string>flat</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 					<dict>

--- a/Consolation3/Consolation3.pkg.recipe
+++ b/Consolation3/Consolation3.pkg.recipe
@@ -82,8 +82,6 @@
 					<string>%RECIPE_CACHE_DIR%/PackageInfo</string>
 					<key>pkgtype</key>
 					<string>flat</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 					<dict>

--- a/Dialog/Dialog.pkg.recipe
+++ b/Dialog/Dialog.pkg.recipe
@@ -96,8 +96,6 @@
 					<string>%version%</string>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 					<dict>

--- a/DispatchView/DispatchView.pkg.recipe
+++ b/DispatchView/DispatchView.pkg.recipe
@@ -82,8 +82,6 @@
 					<string>%RECIPE_CACHE_DIR%/PackageInfo</string>
 					<key>pkgtype</key>
 					<string>flat</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 					<dict>

--- a/KeychainCheck/KeychainCheck.pkg.recipe
+++ b/KeychainCheck/KeychainCheck.pkg.recipe
@@ -82,8 +82,6 @@
 					<string>%RECIPE_CACHE_DIR%/PackageInfo</string>
 					<key>pkgtype</key>
 					<string>flat</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 					<dict>

--- a/Localized-LibreOffice/Localized-LibreOffice.pkg.recipe
+++ b/Localized-LibreOffice/Localized-LibreOffice.pkg.recipe
@@ -79,8 +79,6 @@
 	    			<string>%NAME%_%LANGUAGE_CODE%-%ARCH%-%version%</string>
 					<key>id</key>
 					<string>org.libreoffice.libreoffice-%LANGUAGE_CODE%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/OmniDiskSweeper/OmniDiskSweeper.pkg.recipe
+++ b/OmniDiskSweeper/OmniDiskSweeper.pkg.recipe
@@ -92,8 +92,6 @@
 					<string>%version%</string>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 					<dict>

--- a/Revisionist/Revisionist.pkg.recipe
+++ b/Revisionist/Revisionist.pkg.recipe
@@ -82,8 +82,6 @@
 					<string>%RECIPE_CACHE_DIR%/PackageInfo</string>
 					<key>pkgtype</key>
 					<string>flat</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 					<dict>

--- a/Ulbow/Ulbow.pkg.recipe
+++ b/Ulbow/Ulbow.pkg.recipe
@@ -82,8 +82,6 @@
 					<string>%RECIPE_CACHE_DIR%/PackageInfo</string>
 					<key>pkgtype</key>
 					<string>flat</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 					<dict>

--- a/pCloudDrive/pCloudDrive-M1.munki.recipe
+++ b/pCloudDrive/pCloudDrive-M1.munki.recipe
@@ -114,8 +114,6 @@
 					<string>%appversion%</string>
 					<key>id</key>
 					<string>com.mobileinno.pkg.pCloudDrive</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 					<dict>

--- a/pCloudDrive/pCloudDrive.munki.recipe
+++ b/pCloudDrive/pCloudDrive.munki.recipe
@@ -113,8 +113,6 @@
 					<string>%appversion%</string>
 					<key>id</key>
 					<string>com.mobileinno.pkg.pCloudDrive</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 					<dict>

--- a/xattred/xattred.pkg.recipe
+++ b/xattred/xattred.pkg.recipe
@@ -82,8 +82,6 @@
 					<string>%RECIPE_CACHE_DIR%/PackageInfo</string>
 					<key>pkgtype</key>
 					<string>flat</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 					<dict>


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and removes the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._